### PR TITLE
Bump `ghostwriter/coding-standard` from `dev-main`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d56b22de0bc33c135d51b435e01ed8af",
+    "content-hash": "d14e1c3ef75b4bcaf0ef27322949ee78",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -2170,12 +2170,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "7f141b119721d61069156042d3dd3402087d8938"
+                "reference": "5f66842d4f9727b92be55eea5ec0acebccf7b9d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/7f141b119721d61069156042d3dd3402087d8938",
-                "reference": "7f141b119721d61069156042d3dd3402087d8938",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/5f66842d4f9727b92be55eea5ec0acebccf7b9d3",
+                "reference": "5f66842d4f9727b92be55eea5ec0acebccf7b9d3",
                 "shasum": ""
             },
             "require": {
@@ -2332,7 +2332,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-08-24T15:04:20+00:00"
+            "time": "2025-08-24T19:11:35+00:00"
         },
         {
             "name": "ghostwriter/json",


### PR DESCRIPTION
Bumps `ghostwriter/coding-standard` from `dev-main`.

This pull request changes the following file(s): 

- Update `composer.lock`