### PR TITLE
Bump `symfony/var-dumper` from `v7.3.2` to `v7.3.3`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "~1.6.12",
         "phpunit/phpunit": "~12.3.7",
-        "symfony/var-dumper": "~7.3.2",
+        "symfony/var-dumper": "~7.3.3",
         "vimeo/psalm": "~6.13.1"
     },
     "prefer-stable": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "012ab716e178fd554f13cae545d4ac55",
+    "content-hash": "5512fc3c8ee70d6b1cfff8e6551ca020",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -6686,16 +6686,16 @@
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.3.2",
+            "version": "v7.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "53205bea27450dc5c65377518b3275e126d45e75"
+                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/53205bea27450dc5c65377518b3275e126d45e75",
-                "reference": "53205bea27450dc5c65377518b3275e126d45e75",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
+                "reference": "34d8d4c4b9597347306d1ec8eb4e1319b1e6986f",
                 "shasum": ""
             },
             "require": {
@@ -6749,7 +6749,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.3.2"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.3"
             },
             "funding": [
                 {
@@ -6769,7 +6769,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-29T20:02:46+00:00"
+            "time": "2025-08-13T11:49:31+00:00"
         },
         {
             "name": "theseer/tokenizer",


### PR DESCRIPTION
Bumps `symfony/var-dumper` from `v7.3.2` to `v7.3.3`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`