### PR TITLE
Update ghostwriter/coding-standard to version dev-main#8436d58

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -67,7 +67,9 @@
         "files": [
             "tests/bootstrap.php"
         ],
-        "exclude-from-classmap": ["/tests/"]
+        "exclude-from-classmap": [
+            "/tests/"
+        ]
     },
     "bin": [
         "bin/testify"
@@ -91,15 +93,31 @@
     },
     "scripts": {
         "cache:clear": "rm -rf ./.cache/*",
-        "check": ["@cache:clear", "vendor/ghostwriter/coding-standard/tools/phar/composer validate", "@test"],
-        "docker": ["@docker:build", "@docker:run"],
+        "check": [
+            "@cache:clear",
+            "vendor/ghostwriter/coding-standard/tools/phar/composer validate",
+            "@test"
+        ],
+        "docker": [
+            "@docker:build",
+            "@docker:run"
+        ],
         "docker:build": "docker buildx build --pull --tag workspace .",
         "docker:run": "docker run -v $(PWD):/github/workspace -w=/github/workspace -e GITHUB_DEBUG=1 -e GITHUB_WORKSPACE=/github/workspace -e GITHUB_TOKEN=github-token -e SIGNING_SECRET_KEY=secret-key workspace",
         "git:submodule:update": "git submodule update --depth=1 --init --recursive --recommend-shallow --remote",
-        "infection": ["@xdebug", "vendor/ghostwriter/coding-standard/tools/phar/infection --min-covered-msi=0 --min-msi=0 --show-mutations --threads=max"],
+        "infection": [
+            "@xdebug",
+            "vendor/ghostwriter/coding-standard/tools/phar/infection --min-covered-msi=0 --min-msi=0 --show-mutations --threads=max"
+        ],
         "phpbench": "vendor/ghostwriter/coding-standard/tools/phar/phpbench run --report='extends:aggregate,cols:[benchmark,subject,revs,its,mem_peak,mode,rstdev]' --time-unit=milliseconds ./tests/Benchmark",
-        "phpunit": ["@xdebug", "vendor/ghostwriter/coding-standard/tools/phar/phpunit --do-not-cache-result --colors=always"],
-        "test": ["@phpunit", "@infection"],
+        "phpunit": [
+            "@xdebug",
+            "vendor/ghostwriter/coding-standard/tools/phar/phpunit --do-not-cache-result --colors=always"
+        ],
+        "test": [
+            "@phpunit",
+            "@infection"
+        ],
         "unused": "vendor/ghostwriter/coding-standard/tools/phar/composer-unused --no-interaction --ansi",
         "xdebug": "@putenv XDEBUG_MODE=coverage"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -1064,12 +1064,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "aeec26c153d1937e7f12c46fc754c9de16040118"
+                "reference": "8436d58d10b0e62f5167db050df6b7cfcecaae08"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/aeec26c153d1937e7f12c46fc754c9de16040118",
-                "reference": "aeec26c153d1937e7f12c46fc754c9de16040118",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/8436d58d10b0e62f5167db050df6b7cfcecaae08",
+                "reference": "8436d58d10b0e62f5167db050df6b7cfcecaae08",
                 "shasum": ""
             },
             "require": {
@@ -1119,7 +1119,7 @@
                 "ext-xdebug": "*",
                 "mockery/mockery": "^1.6.12",
                 "nikic/php-parser": "^5.6.2",
-                "phpunit/phpunit": "^12.4.1",
+                "phpunit/phpunit": "^12.4.2",
                 "symfony/var-dumper": "^7.3.5"
             },
             "default-branch": true,
@@ -1226,7 +1226,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-10-28T17:42:53+00:00"
+            "time": "2025-10-30T09:34:21+00:00"
         },
         {
             "name": "ghostwriter/json",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#aeec26c` to `dev-main#8436d58`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`