### PR TITLE
Update ghostwriter/coding-standard to version dev-main#9a94be7

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1919,12 +1919,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "4ece5bebec89bb26ab1b0aac1841f2ce18b91b4b"
+                "reference": "9a94be750f2c54dc30685e836b9182caeb8e9e4f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/4ece5bebec89bb26ab1b0aac1841f2ce18b91b4b",
-                "reference": "4ece5bebec89bb26ab1b0aac1841f2ce18b91b4b",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/9a94be750f2c54dc30685e836b9182caeb8e9e4f",
+                "reference": "9a94be750f2c54dc30685e836b9182caeb8e9e4f",
                 "shasum": ""
             },
             "require": {
@@ -2098,7 +2098,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-08T08:45:29+00:00"
+            "time": "2025-12-08T10:16:41+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#4ece5be` to `dev-main#9a94be7`.

This pull request changes the following file(s): 

- Update `composer.lock`