### PR TITLE
Update ghostwriter/coding-standard to version dev-main#129f1ec

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1919,12 +1919,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "9a94be750f2c54dc30685e836b9182caeb8e9e4f"
+                "reference": "129f1ecdec28bc960a57b18794025878e96d2afa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/9a94be750f2c54dc30685e836b9182caeb8e9e4f",
-                "reference": "9a94be750f2c54dc30685e836b9182caeb8e9e4f",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/129f1ecdec28bc960a57b18794025878e96d2afa",
+                "reference": "129f1ecdec28bc960a57b18794025878e96d2afa",
                 "shasum": ""
             },
             "require": {
@@ -2098,7 +2098,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-08T10:16:41+00:00"
+            "time": "2025-12-10T08:51:36+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#9a94be7` to `dev-main#129f1ec`.

This pull request changes the following file(s): 

- Update `composer.lock`