### PR TITLE
Update ghostwriter/coding-standard to version dev-main#dde737d

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1923,12 +1923,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "8d296eef1470aa4c4833b371aa6f88ab804547e9"
+                "reference": "dde737d153a4060c3c2d792ad50e740d356a34cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/8d296eef1470aa4c4833b371aa6f88ab804547e9",
-                "reference": "8d296eef1470aa4c4833b371aa6f88ab804547e9",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/dde737d153a4060c3c2d792ad50e740d356a34cf",
+                "reference": "dde737d153a4060c3c2d792ad50e740d356a34cf",
                 "shasum": ""
             },
             "require": {
@@ -1987,8 +1987,8 @@
                 "nikic/php-parser": "^5.7.0",
                 "php": "~8.4.0 || ~8.5.0",
                 "phpunit/phpunit": "^12.5.4",
-                "symfony/process": "^8.0.0",
-                "symfony/var-dumper": "^8.0.0"
+                "symfony/process": "^8.0.3",
+                "symfony/var-dumper": "^8.0.3"
             },
             "conflict": {
                 "pestphp/pest": "*"
@@ -2102,7 +2102,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-30T14:16:43+00:00"
+            "time": "2025-12-31T18:02:44+00:00"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -4712,16 +4712,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v8.0.0",
+            "version": "v8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "a0a750500c4ce900d69ba4e9faf16f82c10ee149"
+                "reference": "0cbbd88ec836f8757641c651bb995335846abb78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/a0a750500c4ce900d69ba4e9faf16f82c10ee149",
-                "reference": "a0a750500c4ce900d69ba4e9faf16f82c10ee149",
+                "url": "https://api.github.com/repos/symfony/process/zipball/0cbbd88ec836f8757641c651bb995335846abb78",
+                "reference": "0cbbd88ec836f8757641c651bb995335846abb78",
                 "shasum": ""
             },
             "require": {
@@ -4753,7 +4753,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v8.0.0"
+                "source": "https://github.com/symfony/process/tree/v8.0.3"
             },
             "funding": [
                 {
@@ -4773,7 +4773,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-16T16:25:44+00:00"
+            "time": "2025-12-19T10:01:18+00:00"
         },
         {
             "name": "symfony/var-dumper",


### PR DESCRIPTION
Updates the `ghostwriter/coding-standard` dependency from `dev-main#8d296ee` to `dev-main#dde737d`.

This pull request changes the following file(s): 

- Update `composer.lock`