### PR TITLE
Update ghostwriter/config to version 2.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
         "php": "~8.4.0 || ~8.5.0",
         "ext-mbstring": "*",
         "ghostwriter/case-converter": "^2.2.1",
-        "ghostwriter/config": "^2.1.1",
+        "ghostwriter/config": "^2.1.2",
         "ghostwriter/console": "^0.2.2",
         "ghostwriter/container": "^7.0.0",
         "ghostwriter/event-dispatcher": "^6.1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d2632930763be2ac601b662d7e84c2ff",
+    "content-hash": "32f6062b809e7c5ab454ae14a05868d4",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -97,16 +97,16 @@
         },
         {
             "name": "ghostwriter/config",
-            "version": "2.1.1",
+            "version": "2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/config.git",
-                "reference": "11076c766c7e7c23a4e2806154f0e641edb686fa"
+                "reference": "108d04cba1435d0d2fe1e366f19da869ff9e5284"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/config/zipball/11076c766c7e7c23a4e2806154f0e641edb686fa",
-                "reference": "11076c766c7e7c23a4e2806154f0e641edb686fa",
+                "url": "https://api.github.com/repos/ghostwriter/config/zipball/108d04cba1435d0d2fe1e366f19da869ff9e5284",
+                "reference": "108d04cba1435d0d2fe1e366f19da869ff9e5284",
                 "shasum": ""
             },
             "require": {
@@ -115,9 +115,9 @@
             "require-dev": {
                 "ext-xdebug": "*",
                 "ghostwriter/coding-standard": "dev-main",
-                "ghostwriter/container": "^6.1.1",
+                "ghostwriter/container": "^7.0.0",
                 "mockery/mockery": "^1.6.12",
-                "phpunit/phpunit": "^13.1.3",
+                "phpunit/phpunit": "^13.1.7",
                 "symfony/var-dumper": "^8.0.8"
             },
             "type": "library",
@@ -169,7 +169,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-14T22:24:27+00:00"
+            "time": "2026-04-20T20:57:17+00:00"
         },
         {
             "name": "ghostwriter/console",


### PR DESCRIPTION
Updates the `ghostwriter/config` dependency from `2.1.1` to `2.1.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`