### PR TITLE
Update boundwize/structarmed to version 0.5.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "require-dev": {
         "ext-xdebug": "*",
-        "boundwize/structarmed": "^0.5.1",
+        "boundwize/structarmed": "^0.5.2",
         "ghostwriter/coding-standard": "dev-main",
         "mockery/mockery": "^1.6.12",
         "phpunit/phpunit": "^13.1.9",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec45a8ba9300ea2e3cccae5f1eee759a",
+    "content-hash": "013624229d1b4ffcc8af8bf5b2121c77",
     "packages": [
         {
             "name": "ghostwriter/case-converter",
@@ -1324,20 +1324,21 @@
     "packages-dev": [
         {
             "name": "boundwize/structarmed",
-            "version": "0.5.1",
+            "version": "0.5.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/boundwize/structarmed.git",
-                "reference": "9cae458f50d3633a33f59c1382bcc8cbee17639d"
+                "reference": "f37234c3c1b7ba74ac7b2174c7dcabbb509b9a5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/9cae458f50d3633a33f59c1382bcc8cbee17639d",
-                "reference": "9cae458f50d3633a33f59c1382bcc8cbee17639d",
+                "url": "https://api.github.com/repos/boundwize/structarmed/zipball/f37234c3c1b7ba74ac7b2174c7dcabbb509b9a5e",
+                "reference": "f37234c3c1b7ba74ac7b2174c7dcabbb509b9a5e",
                 "shasum": ""
             },
             "require": {
                 "composer-runtime-api": "^2.0",
+                "fidry/cpu-core-counter": "^1.3",
                 "nikic/php-parser": "^5.7",
                 "php": "^8.2"
             },
@@ -1381,7 +1382,7 @@
             ],
             "support": {
                 "issues": "https://github.com/boundwize/structarmed/issues",
-                "source": "https://github.com/boundwize/structarmed/tree/0.5.1"
+                "source": "https://github.com/boundwize/structarmed/tree/0.5.2"
             },
             "funding": [
                 {
@@ -1389,7 +1390,68 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-05-13T16:56:25+00:00"
+            "time": "2026-05-14T04:43:27+00:00"
+        },
+        {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
         },
         {
             "name": "ghostwriter/coding-standard",


### PR DESCRIPTION
Updates the `boundwize/structarmed` dependency from `0.5.1` to `0.5.2`.

This pull request changes the following file(s): 

- Update `composer.json`
- Update `composer.lock`