### PR TITLE
Update `ghostwriter/coding-standard` to version `dev-main#77ef9a2`

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -1558,12 +1558,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/ghostwriter/coding-standard.git",
-                "reference": "fd35d2745fe3812a99a68c840bd1622cec78784e"
+                "reference": "77ef9a26a1c855936cc7811f319ab069849b937f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/fd35d2745fe3812a99a68c840bd1622cec78784e",
-                "reference": "fd35d2745fe3812a99a68c840bd1622cec78784e",
+                "url": "https://api.github.com/repos/ghostwriter/coding-standard/zipball/77ef9a26a1c855936cc7811f319ab069849b937f",
+                "reference": "77ef9a26a1c855936cc7811f319ab069849b937f",
                 "shasum": ""
             },
             "require": {
@@ -1678,7 +1678,7 @@
                     "type": "paypal"
                 }
             ],
-            "time": "2026-06-01T02:09:13+00:00"
+            "time": "2026-06-04T12:20:37+00:00"
         },
         {
             "name": "ghostwriter/phpunit-assertions",


### PR DESCRIPTION
Updates the [`ghostwriter/coding-standard`](https://packagist.org/packages/ghostwriter/coding-standard) dependency from `dev-main#fd35d27` to `dev-main#77ef9a2`.

This pull request changes the following file(s): 

- Update `composer.lock`